### PR TITLE
feat(crewai): add tool descriptions for CrewAI

### DIFF
--- a/agentic_radar/analysis/crewai/graph_converter.py
+++ b/agentic_radar/analysis/crewai/graph_converter.py
@@ -1,4 +1,4 @@
-from agentic_radar.graph import GraphDefinition, NodeDefinition, EdgeDefinition, NodeType
+from agentic_radar.graph import GraphDefinition, NodeDefinition, EdgeDefinition, NodeType, ToolType
 from agentic_radar.analysis.crewai.models import CrewAIGraph, CrewAINodeType
 from agentic_radar.analysis.crewai.tool_categorizer import categorize_tool
 
@@ -23,17 +23,20 @@ def convert_graph(crewai_graph: CrewAIGraph) -> GraphDefinition:
         category = None
         if node_type == NodeType.TOOL:
             category = categorize_tool(node.name)
+        elif node_type == NodeType.CUSTOM_TOOL:
+            category = ToolType.DEFAULT
 
         output_node = NodeDefinition(
             node_type=node_type,
             name=node.name,
             label=node.name,
             category=category,
+            description=node.description
         )
 
         nodes.append(output_node.model_copy(deep=True))
 
-        if node.type == CrewAINodeType.TOOL:
+        if node.type == CrewAINodeType.TOOL or node.type == CrewAINodeType.CUSTOM_TOOL:
             tools.append(output_node.model_copy(deep=True))
 
     for edge in crewai_graph.edges:

--- a/agentic_radar/analysis/crewai/models/graph.py
+++ b/agentic_radar/analysis/crewai/models/graph.py
@@ -16,6 +16,7 @@ class CrewAINodeType(str, Enum):
 class CrewAINode(BaseModel):
     name: str = Field(..., description="Name of the node")
     type: CrewAINodeType = Field(..., description="Type of the node")
+    description: Optional[str] = Field(default=None, description="Short description of the node, used mainly for tool descriptions")
 
     class Config:
         frozen = True  # Makes it hashable and immutable
@@ -51,7 +52,8 @@ class CrewAIGraph(BaseModel):
         for tool in tools:
             tool_name = tool.name
             tool_type = CrewAINodeType.CUSTOM_TOOL if tool.custom else CrewAINodeType.TOOL
-            self.nodes.add(CrewAINode(name=tool_name, type=tool_type))
+            description = tool.description
+            self.nodes.add(CrewAINode(name=tool_name, type=tool_type, description=description))
 
 
     def connect_agent_to_tools(self, agent: str, tools: list[CrewAITool]):

--- a/agentic_radar/analysis/crewai/models/tool.py
+++ b/agentic_radar/analysis/crewai/models/tool.py
@@ -3,3 +3,4 @@ from pydantic import BaseModel, Field
 class CrewAITool(BaseModel):
     name: str = Field(..., description="Name of the tool")
     custom: bool = Field(False, description="Indicator of whether it is a custom or predefined tool")
+    description: str = Field("", description="Short description of what the tool does")

--- a/agentic_radar/analysis/crewai/parsing/custom_tools.py
+++ b/agentic_radar/analysis/crewai/parsing/custom_tools.py
@@ -1,13 +1,15 @@
 import ast
 import os
 
+from ..models.tool import CrewAITool
+
 
 class CustomToolsCollector(ast.NodeVisitor):
     CREWAI_CUSTOM_TOOL_DECORATOR = "tool"
     CREWAI_CUSTOM_TOOL_BASE_CLASS = "BaseTool"
 
     def __init__(self):
-        self.custom_tool_names = set()
+        self.custom_tools = {}
 
     def visit_FunctionDef(self, node):
         """Track functions that define custom tools by using the 'tools(...)' decorator."""
@@ -16,7 +18,10 @@ class CustomToolsCollector(ast.NodeVisitor):
                 isinstance(decorator, ast.Call)
                 and decorator.func.id == self.CREWAI_CUSTOM_TOOL_DECORATOR
             ):
-                self.custom_tool_names.add(node.name)
+                tool_description = ast.get_docstring(node) or ""
+                self.custom_tools[node.name] = CrewAITool(
+                    name=node.name, custom=True, description=tool_description
+                )
 
         self.generic_visit(node)
 
@@ -29,7 +34,10 @@ class CustomToolsCollector(ast.NodeVisitor):
                 or isinstance(base, ast.Attribute)
                 and base.attr == self.CREWAI_CUSTOM_TOOL_BASE_CLASS
             ):
-                self.custom_tool_names.add(node.name)
+                tool_description = ast.get_docstring(node) or ""
+                self.custom_tools[node.name] = CrewAITool(
+                    name=node.name, custom=True, description=tool_description
+                )
 
         self.generic_visit(node)
 
@@ -40,7 +48,7 @@ class CustomToolsCollector(ast.NodeVisitor):
             root_dir (str): Path to the codebase directory
 
         Returns:
-            set[str]: Set of custom tool names
+            dict[str, CrewAITool]: Dictionary mapping custom tool name to corresponding CrewAITool instance
         """
 
         for root, _, files in os.walk(root_dir):
@@ -50,4 +58,4 @@ class CustomToolsCollector(ast.NodeVisitor):
                         tree = ast.parse(f.read())
                         self.visit(tree)
 
-        return self.custom_tool_names
+        return self.custom_tools

--- a/agentic_radar/analysis/crewai/parsing/predefined_tools.py
+++ b/agentic_radar/analysis/crewai/parsing/predefined_tools.py
@@ -1,6 +1,10 @@
 import ast
 import os
 
+from ..models.tool import CrewAITool
+from ..tool_descriptions import get_crewai_tools_descriptions
+
+
 class PredefinedToolsCollector(ast.NodeVisitor):
     CREWAI_TOOLS_MODULE = "crewai_tools"
 
@@ -20,17 +24,22 @@ class PredefinedToolsCollector(ast.NodeVisitor):
         for target in node.targets:
             if not isinstance(target, ast.Name):
                 continue
-            
+
             if not isinstance(node.value, ast.Call):
                 continue
 
-            if isinstance(node.value.func, ast.Name) and node.value.func.id in self.known_tool_aliases:
+            if (
+                isinstance(node.value.func, ast.Name)
+                and node.value.func.id in self.known_tool_aliases
+            ):
                 self.predefined_tool_vars[target.id] = node.value.func.id
             elif isinstance(node.value, ast.Attribute):
-                if self.CREWAI_TOOLS_MODULE in node.value and node.value.attr in self.known_tool_aliases:
+                if (
+                    self.CREWAI_TOOLS_MODULE in node.value
+                    and node.value.attr in self.known_tool_aliases
+                ):
                     self.predefined_tool_vars[target.id] = node.value.attr
 
-    
     def collect(self, root_dir: str) -> tuple[set, dict]:
         """Parses all Python modules in the given directory and collects predefined tools.
 
@@ -38,7 +47,7 @@ class PredefinedToolsCollector(ast.NodeVisitor):
             root_dir (str): Path to the codebase directory
 
         Returns:
-            tuple[set, dict]: A tuple containing a set of known tool aliases and a dictionary of predefined tool variables
+            tuple[set[str], dict[str, CrewAITool]]: A tuple containing a set of known tool aliases and a dictionary of predefined tool variables
         """
 
         for root, _, files in os.walk(root_dir):
@@ -50,4 +59,15 @@ class PredefinedToolsCollector(ast.NodeVisitor):
                         tree = ast.parse(code)
                         self.visit(tree)
 
-        return self.known_tool_aliases, self.predefined_tool_vars
+        # Add descriptions and wrap tools inside CrewAITool instances 
+        tools_descriptions = get_crewai_tools_descriptions()
+        predefined_tool_vars = {
+            var_name: CrewAITool(
+                name=tool_name,
+                custom=False,
+                description=tools_descriptions.get(tool_name, ""),
+            )
+            for var_name, tool_name in self.predefined_tool_vars.items()
+        }
+
+        return self.known_tool_aliases, predefined_tool_vars

--- a/agentic_radar/analysis/crewai/tool_categories.json
+++ b/agentic_radar/analysis/crewai/tool_categories.json
@@ -33,7 +33,7 @@
   "QdrantVectorSearchTool": "DOCUMENT_LOADER",
   "RagTool": "LLM",
   "ScrapeElementFromWebsiteTool": "DEFAULT",
-  "ScrapeWebsiteTool": "DEFAULT",
+  "ScrapeWebsiteTool": "DOCUMENT_LOADER",
   "ScrapegraphScrapeTool": "DEFAULT",
   "ScrapegraphScrapeToolSchema": "DEFAULT",
   "ScrapflyScrapeWebsiteTool": "DEFAULT",

--- a/agentic_radar/analysis/crewai/tool_descriptions.py
+++ b/agentic_radar/analysis/crewai/tool_descriptions.py
@@ -1,0 +1,204 @@
+import ast
+import importlib.util
+import logging
+import os
+import re
+from typing import Dict, Optional, List, Tuple
+
+
+def is_package_installed(package_name: str) -> bool:
+    """
+    Check if a package is installed in the current environment.
+    
+    Args:
+        package_name: Name of the package to check
+        
+    Returns:
+        True if the package is installed, False otherwise
+    """
+    spec = importlib.util.find_spec(package_name)
+    return spec is not None
+
+
+def parse_init_imports(init_path: str) -> List[Tuple[str, str]]:
+    """
+    Parse the import statements from __init__.py to extract tool classes and their module paths.
+    
+    Args:
+        init_path: Path to the __init__.py file
+    
+    Returns:
+        List of tuples containing (class_name, module_path)
+    """
+    try:
+        with open(init_path, 'r', encoding='utf-8') as file:
+            content = file.read()
+        
+        # Parse the file
+        parsed_ast = ast.parse(content)
+        
+        imports = []
+        
+        # Look for import statements
+        for node in parsed_ast.body:
+            if isinstance(node, ast.ImportFrom):
+                # Get the module path (e.g., '.ai_mind_tool.ai_mind_tool')
+                module_path = node.module
+                
+                # Get the imports (e.g., 'AIMindTool')
+                for name in node.names:
+                    imports.append((name.name, module_path))
+        
+        return imports
+    
+    except Exception as e:
+        logging.warning(f"Error parsing imports from {init_path}: {e}")
+        return []
+
+
+def find_tool_directory(tools_dir: str, module_path: str) -> Optional[str]:
+    """
+    Find the directory containing the tool based on its module path.
+    
+    Args:
+        tools_dir: Base directory of all tools
+        module_path: Relative module path (e.g., '.ai_mind_tool.ai_mind_tool')
+        
+    Returns:
+        Path to the tool directory if found, None otherwise
+    """
+    # Remove leading dot if present
+    if module_path.startswith('.'):
+        module_path = module_path[1:]
+    
+    # Split module path into parts
+    parts = module_path.split('.')
+    
+    # Try to find the tool directory
+    if len(parts) >= 1:
+        # Try direct match (most tools have their own directory)
+        tool_dir = os.path.join(tools_dir, parts[0])
+        if os.path.isdir(tool_dir):
+            return tool_dir
+    
+    return None
+
+
+def extract_readme_content(readme_path: str) -> Optional[str]:
+    """
+    Extract content from a README.md file.
+    
+    Args:
+        readme_path: Path to the README.md file
+        
+    Returns:
+        Content of the README.md file if found, None otherwise
+    """
+    try:
+        if os.path.exists(readme_path):
+            with open(readme_path, 'r', encoding='utf-8') as file:
+                return file.read()
+        return None
+    except Exception as e:
+        logging.warning(f"Error reading README file at {readme_path}: {e}")
+        return None
+
+
+def extract_description_from_readme(readme_content: str) -> Optional[str]:
+    """
+    Extract the description section from a README.md file.
+    
+    Args:
+        readme_content: Content of the README.md file
+        
+    Returns:
+        Description section if found, None otherwise
+    """
+    if not readme_content:
+        return None
+    
+    # Try to find description section
+    description_match = re.search(r'## Description\s+(.*?)(?=##|\Z)', readme_content, re.DOTALL)
+    if description_match:
+        return description_match.group(1).strip()
+    
+    # If no description section found, try to use the content after the title
+    title_match = re.search(r'# (.*?)\s+(.*?)(?=##|\Z)', readme_content, re.DOTALL)
+    if title_match:
+        return title_match.group(2).strip()
+    
+    # If still nothing found, return first paragraph
+    first_para_match = re.search(r'^(.*?)(?=\n\n|\Z)', readme_content, re.DOTALL)
+    if first_para_match:
+        return first_para_match.group(1).strip()
+    
+    return None
+
+
+def get_crewai_tools_descriptions() -> Dict[str, str]:
+    """
+    Extract tool descriptions from README.md files in the tool directories.
+    
+    Returns:
+        Dictionary mapping tool names to their descriptions
+    """
+    # First check if crewai_tools is installed
+    if not is_package_installed("crewai_tools"):
+        logging.warning("crewai_tools is not installed in the current environment.")
+        return {}
+    
+    # Find the package location
+    spec = importlib.util.find_spec("crewai_tools")
+    if not spec or not spec.submodule_search_locations:
+        return {}
+    
+    package_dir = spec.submodule_search_locations[0]
+    tools_dir = os.path.join(package_dir, "tools")
+    init_file = os.path.join(tools_dir, "__init__.py")
+    
+    if not os.path.exists(init_file):
+        logging.warning(f"__init__.py not found at {init_file}")
+        return {}
+    
+    # Parse imports from __init__.py
+    imports = parse_init_imports(init_file)
+    
+    descriptions = {}
+    
+    for class_name, module_path in imports:
+        # Find the tool directory
+        tool_dir = find_tool_directory(tools_dir, module_path)
+
+        if not tool_dir:
+            descriptions[class_name] = f"Tool directory not found for {module_path}"
+            continue
+
+        # Look for README.md in the tool directory
+        readme_path = os.path.join(tool_dir, "README.md")
+        readme_content = extract_readme_content(readme_path)
+        
+        if readme_content:
+            description = extract_description_from_readme(readme_content)
+            if description:
+                descriptions[class_name] = description
+            else:
+                descriptions[class_name] = "No description found in README.md"
+        else:
+            # Try to find README.md by traversing subdirectories
+            readme_found = False
+            for root, _, files in os.walk(tool_dir):
+                if "README.md" in files:
+                    readme_path = os.path.join(root, "README.md")
+                    readme_content = extract_readme_content(readme_path)
+                    if readme_content:
+                        description = extract_description_from_readme(readme_content)
+                        if description:
+                            descriptions[class_name] = description
+                            readme_found = True
+                            break
+            
+            if not readme_found:
+                descriptions[class_name] = "README.md not found for this tool"
+            
+    
+    return descriptions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 
 
 [tool.poetry]
-version = "0.2.0"
+version = "0.2.1"
 
 [project.optional-dependencies]
 langgraph = []


### PR DESCRIPTION
Adds tool descriptions for CrewAI scans:
- for predefined tools: parses description from "## Descriptions" subheading in tool README.md files (found inside `crewai_tools.tools.*` packages)
- for custom tools: takes class/function docstring as tool description