### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,68 @@
+name: "Bug Report 🐞"
+description: "Report a reproducible issue in the project."
+title: "[Bug] "
+labels: ["bug"]
+type: "Bug"
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for the same bug?
+      description: Please check if an issue already exists for the bug you encountered.
+      options:
+      - label: I have checked the existing issues.
+        required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Describe the bug"
+      description: "A clear and concise description of what the bug is."
+      placeholder: "Bug details..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: "Steps to Reproduce"
+      description: "Steps to reproduce the behavior."
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: "Expected behavior"
+      description: "What should happen instead?"
+      placeholder: "Expected behavior details..."
+    validations:
+      required: true
+
+  - type: input
+    id: agentic_radar_version
+    attributes:
+      label: Agentic Radar Version
+      description: What version of Agentic Radar are you using?
+      placeholder: ex. 0.3.0, main, etc.
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - MacOS
+        - Linux
+        - Windows
+        - WSL on Windows
+      default: 0
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Screenshots/Logs (if applicable)"
+      description: "Paste error logs or screenshots here."
+      placeholder: "Logs or error messages..."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Community Support 💬"
+    url: "https://discord.gg/hqbjCck9"
+    about: "Ask general questions and get help from the community."

--- a/.github/ISSUE_TEMPLATE/documentation_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.yaml
@@ -1,0 +1,20 @@
+name: "Documentation Issue 📖"
+description: "Report missing, outdated, or unclear documentation."
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: issue
+    attributes:
+      label: "What needs improvement?"
+      description: "Describe the documentation issue."
+      placeholder: "Describe what’s unclear or missing."
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: "Where is the issue?"
+      description: "Provide a link or file path to the documentation needing improvement."
+      placeholder: "File path or URL..."

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,32 @@
+name: "Feature Request ✨"
+description: "Suggest a new feature or enhancement."
+title: "[Feature] "
+labels: ["enhancement"]
+type: "Feature"
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for the same feature request?
+      description: Please check if a request for that feature already exists.
+      options:
+      - label: I have checked the existing issues.
+        required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Describe the feature request"
+      description: "What problem does this solve? How would it improve the project?"
+      placeholder: "Feature details..."
+    validations:
+      required: true
+      
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Do you have any ideas for the technical implementation?"
+      description: "How would you approach the problem?"
+      placeholder: "Technical solution ideas..."
+    validations:
+      required: false
+  


### PR DESCRIPTION
Adds 3 issue templates + link to Discord community when creating a new issue.

<img width="839" alt="image" src="https://github.com/user-attachments/assets/445b90d6-3d0d-441e-b3e1-0c60009fa178" />

<img width="835" alt="Screenshot 2025-03-18 at 18 44 18" src="https://github.com/user-attachments/assets/6b597b7e-6ff4-4638-a348-06375a0877fe" />
