### PR TITLE
Fix/html-escape-characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Options:
 Commands:
   langgraph  Scan code written with LangGraph
   crewai     Scan code written with CrewAI
+  n8n        Scan a n8n workflow configuration JSON
 ```
 
 

--- a/agentic_radar/cli.py
+++ b/agentic_radar/cli.py
@@ -21,6 +21,7 @@ from agentic_radar.report import (
     NodeDefinition,
     generate,
 )
+from utils import sanitize_graph
 
 
 class Args(BaseModel):
@@ -82,6 +83,8 @@ def analyze_and_generate_report(framework: str, analyzer: Analyzer):
     if len(graph.nodes) <= 2: # Only start and end nodes are present
         print(f"Agentic Radar didn't find any agentic workflow in input directory: {args.input_directory}")
         raise typer.Exit(code=1)
+    
+    sanitize_graph(graph)
     
     print("Mapping vulnerabilities")
     map_vulnerabilities(graph)

--- a/agentic_radar/cli.py
+++ b/agentic_radar/cli.py
@@ -21,7 +21,8 @@ from agentic_radar.report import (
     NodeDefinition,
     generate,
 )
-from utils import sanitize_graph
+
+from .utils import sanitize_graph
 
 
 class Args(BaseModel):

--- a/agentic_radar/cli.py
+++ b/agentic_radar/cli.py
@@ -22,7 +22,7 @@ from agentic_radar.report import (
     generate,
 )
 
-from .utils import sanitize_graph
+from agentic_radar.utils import sanitize_graph
 
 
 class Args(BaseModel):

--- a/agentic_radar/cli.py
+++ b/agentic_radar/cli.py
@@ -21,7 +21,6 @@ from agentic_radar.report import (
     NodeDefinition,
     generate,
 )
-
 from agentic_radar.utils import sanitize_graph
 
 

--- a/agentic_radar/report/templates/template.html.jinja
+++ b/agentic_radar/report/templates/template.html.jinja
@@ -45,13 +45,13 @@
                         </div>
                         <div style="width: 100%; border-right: 0.50px #D4D4D4 solid; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: inline-flex">
                             <div style="align-self: stretch; padding: 6px; border-bottom: 0.50px #D4D4D4 solid; justify-content: flex-start; align-items: center; gap: 12px; display: inline-flex">
-                                <div style="flex: 40%; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{project_name}}</div>
+                                <div style="flex: 40%; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{project_name|e}}</div>
                             </div>
                             <div style="align-self: stretch; padding: 6px; border-bottom: 0.50px #D4D4D4 solid; justify-content: flex-start; align-items: center; gap: 12px; display: inline-flex">
-                                <div style="flex: 40%; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{timestamp}}</div>
+                                <div style="flex: 40%; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{timestamp|e}}</div>
                             </div>
                             <div style="align-self: stretch; padding: 6px; border-bottom: 0.50px #D4D4D4 solid; justify-content: flex-start; align-items: center; gap: 12px; display: inline-flex">
-                                <div style="flex: 40%; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{framework}}</div>
+                                <div style="flex: 40%; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{framework|e}}</div>
                             </div>
                         </div>
                     </div>
@@ -219,9 +219,9 @@
                         </tr>
                         {% for tool in tools %}
                         <tr style="font-family: Inter; font-weight: 400; font-size:8px; text-align: justify; line-height: 150%">
-                            <td style="padding: 3.5px; border-right: 0.50px #D4D4D4 solid; border-bottom: 0.50px #D4D4D4 solid;">{{tool.name}}</td>
-                            <td style="padding: 3.5px; border-right: 0.50px #D4D4D4 solid; border-bottom: 0.50px #D4D4D4 solid;">{{tool.category}}</td>
-                            <td style="padding: 3.5px; border-right: 0.50px #D4D4D4 solid; border-bottom: 0.50px #D4D4D4 solid;">{{tool.description}}</td>
+                            <td style="padding: 3.5px; border-right: 0.50px #D4D4D4 solid; border-bottom: 0.50px #D4D4D4 solid;">{{tool.name|e}}</td>
+                            <td style="padding: 3.5px; border-right: 0.50px #D4D4D4 solid; border-bottom: 0.50px #D4D4D4 solid;">{{tool.category|e}}</td>
+                            <td style="padding: 3.5px; border-right: 0.50px #D4D4D4 solid; border-bottom: 0.50px #D4D4D4 solid;">{{tool.description|e}}</td>
                             <td style="padding: 3.5px; border-bottom: 0.50px #D4D4D4 solid;">{{tool.vulnerabilities | length}}</td>
                         </tr>
                         {% endfor %}
@@ -238,7 +238,7 @@
                 <div style="width: 100%; margin-top:20px; flex-direction: column; justify-content: center; align-items: center; gap: 20px; display: inline-flex">
                     <div style="align-self: stretch; flex-direction: column; justify-content: flex-start; align-items: flex-start; gap: 8px; display: flex">
                         <div style="align-self: stretch; justify-content: flex-start; align-items: center; gap: 4px; display: inline-flex">
-                            <div style="color: black; font-size: 12px; font-family: Inter; font-weight: 600; line-height: 12px; word-wrap: break-word">{{tool.name}}</div>
+                            <div style="color: black; font-size: 12px; font-family: Inter; font-weight: 600; line-height: 12px; word-wrap: break-word">{{tool.name|e}}</div>
                         </div>
                         {% for v in tool.vulnerabilities %}
                         <div style="width:100%; align-self: stretch; border: 0.50px #D4D4D4 solid; justify-content: flex-start; align-items: flex-start; display: inline-flex">
@@ -248,7 +248,7 @@
                                         <div style="flex: 1 1 0; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 600; line-height: 15px; word-wrap: break-word">Vulnerability</div>
                                     </div>
                                     <div style="flex: 60%; padding: 6px; border-bottom: 0.50px #D4D4D4 solid; justify-content: flex-start; align-items: flex-start; gap: 12px; display: flex">
-                                        <div style="flex: 1 1 0; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word"><b>{{v.name}}</b></div>
+                                        <div style="flex: 1 1 0; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word"><b>{{v.name|e}}</b></div>
                                     </div>
                                 </div>
                                 <div style="align-self: stretch; justify-content: flex-start; align-items: center; display: inline-flex">
@@ -256,7 +256,7 @@
                                         <div style="flex: 1 1 0; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 600; line-height: 15px; word-wrap: break-word">Description</div>
                                     </div>
                                     <div style="flex: 60%; padding: 6px; border-bottom: 0.50px #D4D4D4 solid; justify-content: flex-start; align-items: flex-start; gap: 12px; display: flex">
-                                        <div style="flex: 1 1 0; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{v.description}}</div>
+                                        <div style="flex: 1 1 0; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{v.description|e}}</div>
                                     </div>
                                 </div>
                                 <div style="align-self: stretch; justify-content: flex-start; align-items: center; display: inline-flex">
@@ -274,7 +274,7 @@
                                         <div style="flex: 1 1 0; text-align: justify; color: black; font-size: 10px; font-family: Inter; font-weight: 600; line-height: 15px; word-wrap: break-word">Remediation Steps</div>
                                     </div>
                                     <div style="flex: 60%; padding: 6px; border-bottom: 0.50px #D4D4D4 solid; justify-content: flex-start; align-items: flex-start; gap: 12px; display: flex">
-                                        <div style="flex: 1 1 0; text-align: justify; white-space: pre-wrap; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{v.remediation}}</div>
+                                        <div style="flex: 1 1 0; text-align: justify; white-space: pre-wrap; color: black; font-size: 10px; font-family: Inter; font-weight: 400; line-height: 15px; word-wrap: break-word">{{v.remediation|e}}</div>
                                     </div>
                                 </div>
                             </div>

--- a/agentic_radar/utils.py
+++ b/agentic_radar/utils.py
@@ -1,6 +1,6 @@
 import html
 
-from .graph import GraphDefinition
+from agentic_radar.graph import GraphDefinition
 
 
 def sanitize_text(text: str) -> str:

--- a/agentic_radar/utils.py
+++ b/agentic_radar/utils.py
@@ -1,5 +1,7 @@
-from graph import GraphDefinition
 import html
+
+from .graph import GraphDefinition
+
 
 def sanitize_text(text: str) -> str:
     return html.escape(text)

--- a/agentic_radar/utils.py
+++ b/agentic_radar/utils.py
@@ -1,0 +1,32 @@
+from graph import GraphDefinition
+import html
+
+def sanitize_text(text: str) -> str:
+    return html.escape(text)
+
+def sanitize_graph(graph: GraphDefinition) -> None:
+    nodes = graph.nodes
+    edges = graph.edges
+    tools = graph.tools
+
+    for node in nodes:
+        if node.name is not None:
+            node.name = sanitize_text(node.name)
+        if node.description is not None:
+            node.description = sanitize_text(node.description)
+        if node.label is not None:
+            node.label = sanitize_text(node.label)
+    
+    for edge in edges:
+        if edge.start is not None:
+            edge.start = sanitize_text(edge.start)
+        if edge.end is not None:
+            edge.end = sanitize_text(edge.end)
+
+    for tool in tools:
+        if tool.name is not None:
+            tool.name = sanitize_text(tool.name)
+        if tool.description is not None:
+            tool.description = sanitize_text(tool.description)
+        if tool.label is not None:
+            tool.label = sanitize_text(tool.label)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 
 
 [tool.poetry]
-version = "0.4.0"
+version = "0.4.1"
 
 [project.optional-dependencies]
 langgraph = []


### PR DESCRIPTION
This fix is designed to resolve the issues of certain special charactrs not being escaped while being used in the HTML report.
This is due to certain elements in the report being extracted by parsing the workflow, without being sanitized.

Resolves #47