### PR TITLE
feat(openai-agents): add additional agent information to report

### DIFF
--- a/agentic_radar/analysis/openai_agents/graph.py
+++ b/agentic_radar/analysis/openai_agents/graph.py
@@ -1,5 +1,8 @@
 from agentic_radar.analysis.openai_agents.models import Agent, Tool
 from agentic_radar.graph import (
+    Agent as ReportAgent,
+)
+from agentic_radar.graph import (
     EdgeDefinition,
     GraphDefinition,
     NodeDefinition,
@@ -48,7 +51,18 @@ def create_graph_definition(
                 )
 
     nodes, edges = _add_start_end_nodes(nodes=nodes, edges=edges)
-    return GraphDefinition(name=graph_name, nodes=nodes, edges=edges, tools=tools)
+
+    report_agents = [
+        ReportAgent(
+            name=agent.name,
+            llm=agent.model or "gpt-4o",
+            system_prompt=agent.instructions or "",
+        )
+        for agent in agent_assignments.values()
+    ]
+    return GraphDefinition(
+        name=graph_name, nodes=nodes, edges=edges, tools=tools, agents=report_agents
+    )
 
 
 def _get_agent_node(agent: Agent) -> NodeDefinition:

--- a/agentic_radar/analysis/openai_agents/models.py
+++ b/agentic_radar/analysis/openai_agents/models.py
@@ -13,3 +13,5 @@ class Agent(BaseModel):
     name: str
     tools: list[Tool]
     handoffs: list[str]
+    instructions: Optional[str] = None
+    model: Optional[str] = None

--- a/agentic_radar/analysis/openai_agents/parsing/ast_utils.py
+++ b/agentic_radar/analysis/openai_agents/parsing/ast_utils.py
@@ -152,7 +152,7 @@ def has_decorator(
     return find_decorator_by_name(node, decorator_name) is not None
 
 
-def get_string_keyword_arg(node: ast.Call, keyword_name: str) -> str:
+def get_string_keyword_arg(node: ast.Call, keyword_name: str) -> Optional[str]:
     """
     Extract the value of a keyword argument from an ast.Call node if it is a string.
 
@@ -161,11 +161,11 @@ def get_string_keyword_arg(node: ast.Call, keyword_name: str) -> str:
         keyword_name (str): The name of the keyword argument to extract.
 
     Returns:
-        str: The string value of the keyword argument.
+        Optional[str]: The string value of the keyword argument, or None if the keyword argument is missing.
 
     Raises:
-        ValueError: If the keyword argument is missing or not a string.
         TypeError: If the node is not an ast.Call instance.
+        ValueError: If the keyword argument is not a string.
     """
     if not isinstance(node, ast.Call):
         raise TypeError(f"Expected ast.Call, got {type(node).__name__}")
@@ -173,7 +173,7 @@ def get_string_keyword_arg(node: ast.Call, keyword_name: str) -> str:
     keyword_value = get_keyword_arg_value(node, keyword_name)
 
     if keyword_value is None:
-        raise ValueError(f"Keyword argument '{keyword_name}' not found")
+        return None
 
     if not (
         isinstance(keyword_value, ast.Constant) and isinstance(keyword_value.value, str)

--- a/agentic_radar/analysis/openai_agents/parsing/tools.py
+++ b/agentic_radar/analysis/openai_agents/parsing/tools.py
@@ -64,7 +64,11 @@ class ToolsVisitor(ast.NodeVisitor):
         tool_name = node.name
         if isinstance(tool_decorator, ast.Call):
             try:
-                tool_name = get_string_keyword_arg(tool_decorator, "name_override")
+                tool_name_override = get_string_keyword_arg(
+                    tool_decorator, "name_override"
+                )
+                if tool_name_override:
+                    tool_name = tool_name_override
             except (ValueError, TypeError):
                 pass
         description = ast.get_docstring(node) or ""


### PR DESCRIPTION
Adds additional information about Agents in the analyzed **OpenAI Agents** workflows:
- LLM (taken from `model` keyword argument of `Agent` constructor)
- System Prompt (taken from `instructions` keyword argument of `Agent` constructor)

Analogous to https://github.com/splx-ai/agentic-radar/pull/64.