### PR TITLE
feat(n8n): generate a report for each workflow & flags

### DIFF
--- a/agentic_radar/analysis/analyze.py
+++ b/agentic_radar/analysis/analyze.py
@@ -1,8 +1,9 @@
 import abc
+from typing import List, Union
 
 from ..graph import GraphDefinition
 
 
 class Analyzer(abc.ABC):
-    def analyze(self, root_directory: str) -> GraphDefinition:
+    def analyze(self, root_directory: str) -> Union[GraphDefinition, List[GraphDefinition]]:
         raise NotImplementedError()

--- a/agentic_radar/analysis/n8n/analyze.py
+++ b/agentic_radar/analysis/n8n/analyze.py
@@ -10,8 +10,9 @@ from .parsing import parse_n8n_connections, parse_n8n_nodes
 
 
 class N8nAnalyzer(Analyzer):
-    def __init__(self):
+    def __init__(self, connected_only=False):
         super().__init__()
+        self.connected_only = connected_only
 
     def parse_n8n_config_file(
         self, file_path: str
@@ -44,6 +45,11 @@ class N8nAnalyzer(Analyzer):
                     n8n_nodes, n8n_connections, workflow_name = self.parse_n8n_config_file(file_path)
 
                     if n8n_nodes and n8n_connections:
+                        # Skip workflows without connections if connected_only is True
+                        if self.connected_only and not n8n_connections:
+                            print(f"Skipping workflow '{workflow_name}' as it has no connections")
+                            continue
+                            
                         nodes, tools = convert_nodes(n8n_nodes)
                         edges = convert_connections(n8n_connections)
 

--- a/agentic_radar/analysis/n8n/analyze.py
+++ b/agentic_radar/analysis/n8n/analyze.py
@@ -10,9 +10,10 @@ from .parsing import parse_n8n_connections, parse_n8n_nodes
 
 
 class N8nAnalyzer(Analyzer):
-    def __init__(self, connected_only=False):
+    def __init__(self, connected_only=False, langchain_only=False):
         super().__init__()
         self.connected_only = connected_only
+        self.langchain_only = langchain_only
 
     def parse_n8n_config_file(
         self, file_path: str
@@ -35,6 +36,13 @@ class N8nAnalyzer(Analyzer):
 
         return n8n_nodes, n8n_connections, workflow_name
 
+    def has_langchain_nodes(self, n8n_nodes: List[N8nNode]) -> bool:
+        """Check if any of the nodes are LangChain nodes."""
+        for node in n8n_nodes:
+            if "langchain" in node.type.lower():
+                return True
+        return False
+
     def analyze(self, root_directory: str) -> List[GraphDefinition]:
         workflow_graphs = []
 
@@ -48,6 +56,11 @@ class N8nAnalyzer(Analyzer):
                         # Skip workflows without connections if connected_only is True
                         if self.connected_only and not n8n_connections:
                             print(f"Skipping workflow '{workflow_name}' as it has no connections")
+                            continue
+                        
+                        # Skip workflows without LangChain nodes if langchain_only is True
+                        if self.langchain_only and not self.has_langchain_nodes(n8n_nodes):
+                            print(f"Skipping workflow '{workflow_name}' as it has no LangChain nodes")
                             continue
                             
                         nodes, tools = convert_nodes(n8n_nodes)

--- a/agentic_radar/cli.py
+++ b/agentic_radar/cli.py
@@ -140,8 +140,17 @@ def crewai():
 
 
 @app.command("n8n", help="Scan a n8n workflow configuration JSON")
-def n8n():
-    analyze_and_generate_report("n8n", N8nAnalyzer())
+def n8n(
+    connected_only: Annotated[
+        bool,
+        typer.Option(
+            "--connected-only",
+            help="Only generate reports for workflows with connected nodes",
+        ),
+    ] = False,
+):
+    print(f"Connected-only mode: {'Enabled' if connected_only else 'Disabled'}")
+    analyze_and_generate_report("n8n", N8nAnalyzer(connected_only=connected_only))
 
 
 @app.command("openai-agents", help="Scan code written with OpenAI Agents SDK")

--- a/agentic_radar/cli.py
+++ b/agentic_radar/cli.py
@@ -148,9 +148,17 @@ def n8n(
             help="Only generate reports for workflows with connected nodes",
         ),
     ] = False,
+    langchain_only: Annotated[
+        bool,
+        typer.Option(
+            "--langchain-only",
+            help="Only generate reports for workflows that contain LangChain nodes",
+        ),
+    ] = False,
 ):
     print(f"Connected-only mode: {'Enabled' if connected_only else 'Disabled'}")
-    analyze_and_generate_report("n8n", N8nAnalyzer(connected_only=connected_only))
+    print(f"LangChain-only mode: {'Enabled' if langchain_only else 'Disabled'}")
+    analyze_and_generate_report("n8n", N8nAnalyzer(connected_only=connected_only, langchain_only=langchain_only))
 
 
 @app.command("openai-agents", help="Scan code written with OpenAI Agents SDK")


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the `agentic_radar` project, focusing on improving the flexibility of the `N8nAnalyzer`, supporting multiple workflows, and enhancing the CLI functionality. The most important changes include updating the `Analyzer` interface to handle multiple graphs, refactoring the `N8nAnalyzer` to support additional filtering options, and improving the CLI to handle multiple workflows and generate unique reports.

### Enhancements to `Analyzer` and `N8nAnalyzer`:

* Updated the `Analyzer` interface to return either a single `GraphDefinition` or a list of `GraphDefinition` objects, allowing support for analyzing multiple workflows. (`agentic_radar/analysis/analyze.py`)
* Refactored `N8nAnalyzer`:
  * Added `connected_only` and `langchain_only` options to filter workflows based on connections and LangChain nodes. (`agentic_radar/analysis/n8n/analyze.py`)
  * Replaced the `parse_n8n_configs` method with a more modular `parse_n8n_config_file` method for analyzing individual files. (`agentic_radar/analysis/n8n/analyze.py`)

### CLI improvements:

* Updated the `analyze_and_generate_report` function to handle multiple workflows, generate unique report filenames, and skip workflows that do not meet specific criteria. (`agentic_radar/cli.py`) [[1]](diffhunk://#diff-0d0fc9a10f46b8d0d8951348a68b2e9eded007e0fa99d8cc226c8632725a0065L83-R101) [[2]](diffhunk://#diff-0d0fc9a10f46b8d0d8951348a68b2e9eded007e0fa99d8cc226c8632725a0065L108-R129)
* Enhanced the `n8n` CLI command to include `--connected-only` and `--langchain-only` options, providing users with more control over which workflows to analyze. (`agentic_radar/cli.py`)