### PR TITLE
fix: set font color in report tables to black

### DIFF
--- a/agentic_radar/report/templates/template.html.jinja
+++ b/agentic_radar/report/templates/template.html.jinja
@@ -73,6 +73,11 @@ const __INLINE_DATA = {{graph}};
     overflow-wrap: break-word;
 }
 
+/* Set font color to black for all table text */
+table, th, td {
+    color: black;
+}
+
 </style>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Adds CSS classes to Jinja template which make all the tables in the report have black font.