### PR TITLE
feat: Export Graph as JSON

### DIFF
--- a/agentic_radar/cli.py
+++ b/agentic_radar/cli.py
@@ -94,29 +94,19 @@ def scan(
             envvar="AGENTIC_RADAR_HARDEN_PROMPTS",
         ),
     ] = False,
-    export_graph: Annotated[
+    export_graph_json: Annotated[
         bool,
         typer.Option(
-            "--export-graph",
-            help="Export the graph in JSON format and exit. The output file is specified by the --output-file or -o flag.",
+            "--export-graph-json",
+            help="Export the graph in JSON format and exit. The output file is specified by the --output-file or -o flag. If the output file ends with .html, it will be replaced with .json.",
             is_flag=True,
-            envvar="AGENTIC_RADAR_EXPORT_GRAPH",
+            envvar="AGENTIC_RADAR_EXPORT_GRAPH_JSON",
         ),
     ] = False,
 ):
     if not os.path.isdir(input_directory):
         print(f"Input directory '{input_directory}' does not exist.")
         raise typer.Exit(code=1)
-
-    # Validate output_file extension
-    if export_graph:
-        if not output_file.endswith(".json"):
-            print("Error: --output-file must end with .json when using --export-graph")
-            raise typer.Exit(code=1)
-    else:
-        if not output_file.endswith(".html"):
-            print("Error: --output-file must end with .html")
-            raise typer.Exit(code=1)
 
     analyzer: Analyzer
     if framework == AgenticFramework.langgraph:
@@ -139,7 +129,7 @@ def scan(
         input_directory=input_directory,
         output_file=output_file,
         harden_prompts=harden_prompts,
-        export_graph=export_graph,
+        export_graph_json=export_graph_json,
     )
 
 
@@ -149,7 +139,7 @@ def analyze_and_generate_report(
     input_directory: str,
     output_file: str,
     harden_prompts: bool,
-    export_graph: bool = False,
+    export_graph_json: bool = False,
 ):
     print(f"Analyzing {input_directory} for {framework} graphs")
     graph = analyzer.analyze(input_directory)
@@ -161,7 +151,8 @@ def analyze_and_generate_report(
         raise typer.Exit(code=1)
     sanitize_graph(graph)
 
-    if export_graph:
+    if export_graph_json:
+        output_file = output_file.replace(".html", ".json")
         with open(output_file, "w") as f:
             f.write(graph.model_dump_json(indent=2))
         print(f"Graph exported to {output_file}")


### PR DESCRIPTION
Adds support for exporting graph data to a JSON file:
- adds `--export-graph` flag to the `scan` command
- saves the `GraphDefinition` output from the `analyzer` to the output specified by `--output-file` or `-o`
- validates that the output file has the right extension: .json when using `--export-graph`, or .html in all other cases 