### PR TITLE
fix(autogen): show teamless agents in the report

### DIFF
--- a/agentic_radar/analysis/autogen/agentchat/analyze.py
+++ b/agentic_radar/analysis/autogen/agentchat/analyze.py
@@ -29,6 +29,13 @@ class AutogenAgentChatAnalyzer(Analyzer):
             trees, model_clients, function_tools, all_functions
         )
         teams = find_teams(trees, agent_assignments)
-        graph = create_graph_definition(Path(root_directory).name, teams)
+
+        agents_with_team = set([member for team in teams for member in team.members])
+        teamless_agents = [
+            a for a in agent_assignments.values() if a.name not in agents_with_team
+        ]
+        graph = create_graph_definition(
+            Path(root_directory).name, teams, teamless_agents
+        )
 
         return graph


### PR DESCRIPTION
Update for AutoGen AgentChat:
- includes Agents without a [Team](https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/tutorial/teams.html) in the report
- connects all of them to START and END nodes automatically