### PR TITLE
feat(autogen): add mcp detection for autogen agentchat

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ This matrix shows which agentic frameworks support all the Agentic Radar feature
 | CrewAI         | ✅          | ❌         | ✅          |      ❌        |
 | n8n            | ✅          | ❌          | ❌          |     ❌        |
 | LangGraph      | ✅          | ✅          | ❌          |     ❌         |
-| Autogen     | ✅          | ❌          | ✅          |     ❌         |
+| Autogen     | ✅          | ✅          | ✅          |     ❌         |
 
 Are there some features you would like to see happen first? Vote anonymously [here](https://strawpoll.com/w4nWWMqqlnA) or [open a GitHub Issue](https://github.com/splx-ai/agentic-radar/issues/new/choose).
 

--- a/agentic_radar/analysis/autogen/agentchat/analyze.py
+++ b/agentic_radar/analysis/autogen/agentchat/analyze.py
@@ -5,6 +5,11 @@ from agentic_radar.analysis.ast_utils import walk_and_parse_python_files
 from agentic_radar.graph import GraphDefinition
 
 from .graph import create_graph_definition
+from .mcp import (
+    find_listed_mcp_tool_adapters,
+    find_server_params,
+    find_single_mcp_tool_adapters,
+)
 from .parse import (
     find_agent_assignments,
     find_all_functions,
@@ -25,8 +30,16 @@ class AutogenAgentChatAnalyzer(Analyzer):
         model_imports = find_model_client_imports(trees)
         model_clients = find_model_client_assignments(trees, model_imports)
         function_tools = find_function_tool_assignments(trees, all_functions)
+        mcp_servers = find_server_params(trees)
+        mcp_adapters_to_servers = find_single_mcp_tool_adapters(trees, mcp_servers)
+        listed_mcp_tool_adapters = find_listed_mcp_tool_adapters(trees, mcp_servers)
         agent_assignments = find_agent_assignments(
-            trees, model_clients, function_tools, all_functions
+            trees,
+            model_clients,
+            function_tools,
+            all_functions,
+            mcp_adapters_to_servers,
+            listed_mcp_tool_adapters,
         )
         teams = find_teams(trees, agent_assignments)
 

--- a/agentic_radar/analysis/autogen/agentchat/graph.py
+++ b/agentic_radar/analysis/autogen/agentchat/graph.py
@@ -1,3 +1,5 @@
+import re
+
 from agentic_radar.graph import (
     Agent,
     EdgeDefinition,
@@ -102,6 +104,22 @@ def _add_agent_node(
         label=agent.name,
     )
     nodes.append(agent_node)
+
+    for mcp_server in agent.mcp_servers:
+        name_from_desc = re.findall(
+            r"\"@modelcontextprotocol/(.+)\"", mcp_server.description
+        )
+        name = name_from_desc[0] if name_from_desc else mcp_server.name
+        mcp_node = NodeDefinition(
+            name=name,
+            label=name,
+            description=mcp_server.description,
+            type=NodeType.MCP_SERVER,
+        )
+        nodes.append(mcp_node)
+        edges.append(
+            EdgeDefinition(start=agent.name, end=mcp_node.name, condition="uses_mcp")
+        )
 
     if agent.tools:
         for tool in agent.tools:

--- a/agentic_radar/analysis/autogen/agentchat/mcp.py
+++ b/agentic_radar/analysis/autogen/agentchat/mcp.py
@@ -1,0 +1,158 @@
+import ast
+import json
+
+from agentic_radar.analysis.ast_utils import (
+    kwargize_params,
+    parse_simple_function_call_assignment,
+)
+
+from .models import MCPServer
+
+MCP_SERVER_TYPES = [
+    "StdioServerParams",
+    "SseServerParams",
+    "StreamableHttpServerParams",
+]
+STDIO_SERVER_PARAM_NAMES = [
+    "command",
+    "args",
+    "env",
+    "cwd",
+    "encoding",
+    "encoding_error_handler",
+    "type",
+    "read_timeout_seconds",
+]
+SSE_SERVER_PARAM_NAMES = ["type", "url", "headers", "timeout", "sse_read_timeout"]
+STREAMABLE_HTTP_SERVER_PARAM_NAMES = [
+    "type",
+    "url",
+    "headers",
+    "timeout",
+    "sse_read_timeout",
+    "terminate_on_close",
+]
+TOOL_ADAPTER_FACTORY_FUNCTION = "from_server_params"
+TOOL_ADAPTER_FACTORY_FUNCTION_PARAM_NAMES = ["server_params", "tool_name"]
+MCP_SERVER_TOOLS_FACTORY_FUNCTION = "mcp_server_tools"
+MCP_SERVER_TOOLS_FACTORY_FUNCTION_PARAM_NAMES = ["server_params", "session"]
+
+
+def find_server_params(trees: list[ast.AST]) -> dict[str, MCPServer]:
+    servers: dict[str, MCPServer] = {}
+    for tree in trees:
+        for node in ast.walk(tree):
+            simple_function_call_assignment = parse_simple_function_call_assignment(
+                node
+            )
+            if not simple_function_call_assignment:
+                continue
+
+            if simple_function_call_assignment.function_name not in MCP_SERVER_TYPES:
+                continue
+
+            if simple_function_call_assignment.function_name == "StdioServerParams":
+                param_names = STDIO_SERVER_PARAM_NAMES
+            elif simple_function_call_assignment.function_name == "SseServerParams":
+                param_names = SSE_SERVER_PARAM_NAMES
+            else:
+                param_names = STREAMABLE_HTTP_SERVER_PARAM_NAMES
+
+            server_params = kwargize_params(
+                simple_function_call_assignment.args,
+                simple_function_call_assignment.kwargs,
+                param_names,
+            )
+
+            # Remove None values for cleaner output
+            server_params = {k: v for k, v in server_params.items() if v is not None}
+
+            servers[simple_function_call_assignment.target] = MCPServer(
+                name=simple_function_call_assignment.target,
+                description=json.dumps(server_params, indent=2),
+            )
+    return servers
+
+
+def find_single_mcp_tool_adapters(
+    trees: list[ast.AST], mcp_servers: dict[str, MCPServer]
+) -> dict[str, MCPServer]:
+    """Finds assignments like:
+        adapter = await StreamableHttpMcpToolAdapter.from_server_params(server_params, "translation_tool")
+
+    Args:
+        trees (list[ast.AST]): The abstract syntax trees to search.
+        mcp_servers (dict[str, MCPServer]): The MCP server params to use for finding adapters.
+
+    Returns:
+        dict[str, MCPServer]: A dictionary mapping adapter names to their MCP server instances.
+    """
+    adapters: dict[str, MCPServer] = {}
+    for tree in trees:
+        for node in ast.walk(tree):
+            simple_function_call_assignment = parse_simple_function_call_assignment(
+                node
+            )
+            if not simple_function_call_assignment:
+                continue
+
+            if (
+                simple_function_call_assignment.function_name
+                != TOOL_ADAPTER_FACTORY_FUNCTION
+            ):
+                continue
+
+            adapter_params = kwargize_params(
+                simple_function_call_assignment.args,
+                simple_function_call_assignment.kwargs,
+                TOOL_ADAPTER_FACTORY_FUNCTION_PARAM_NAMES,
+            )
+
+            server_name = adapter_params.get("server_params")
+            tool_name = adapter_params.get("tool_name")
+            if server_name not in mcp_servers:
+                continue
+            if not isinstance(tool_name, str):
+                tool_name = "unknown-tool"
+            mcp_server = mcp_servers[server_name].model_copy()
+            mcp_server.tools.add(tool_name)
+            adapters[simple_function_call_assignment.target] = mcp_server
+    return adapters
+
+
+def find_listed_mcp_tool_adapters(
+    trees: list[ast.AST], mcp_servers: dict[str, MCPServer]
+) -> dict[str, MCPServer]:
+    """Finds assignments like:
+    tools = await mcp_server_tools(server_params)
+
+    Returns a dictionary mapping variables which contain list of adapters to their MCP server instances.
+    """
+    vars_to_adapters: dict[str, MCPServer] = {}
+    for tree in trees:
+        for node in ast.walk(tree):
+            simple_function_call_assignment = parse_simple_function_call_assignment(
+                node
+            )
+            if not simple_function_call_assignment:
+                continue
+
+            if (
+                simple_function_call_assignment.function_name
+                != MCP_SERVER_TOOLS_FACTORY_FUNCTION
+            ):
+                continue
+
+            adapter_params = kwargize_params(
+                simple_function_call_assignment.args,
+                simple_function_call_assignment.kwargs,
+                MCP_SERVER_TOOLS_FACTORY_FUNCTION_PARAM_NAMES,
+            )
+
+            server_name = adapter_params.get("server_params")
+            if server_name not in mcp_servers:
+                continue
+            mcp_server = mcp_servers[server_name].model_copy()
+            vars_to_adapters[simple_function_call_assignment.target] = mcp_server
+
+    return vars_to_adapters

--- a/agentic_radar/analysis/autogen/agentchat/models.py
+++ b/agentic_radar/analysis/autogen/agentchat/models.py
@@ -18,12 +18,19 @@ class FunctionTool(BaseModel):
     description: str
 
 
+class MCPServer(BaseModel):
+    name: str
+    description: str
+    tools: set[str] = set()
+
+
 class Agent(BaseModel):
     name: str
     tools: list[FunctionTool]
     llm: str = ""
     system_prompt: str = ""
     handoffs: list[str] = []
+    mcp_servers: list[MCPServer] = []
 
 
 class TeamType(str, Enum):

--- a/examples/autogen/agentchat/autogen_mcp_1/autogen_mcp_1.py
+++ b/examples/autogen/agentchat/autogen_mcp_1/autogen_mcp_1.py
@@ -1,0 +1,36 @@
+import asyncio
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.tools.mcp import SseMcpToolAdapter, SseServerParams
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_core import CancellationToken
+
+
+async def main() -> None:
+    # Create server params for the remote MCP service
+    server_params = SseServerParams(
+        url="https://api.example.com/mcp",
+        headers={"Authorization": "Bearer your-api-key", "Content-Type": "application/json"},
+        timeout=30,  # Connection timeout in seconds
+    )
+
+    # Get the translation tool from the server
+    adapter = await SseMcpToolAdapter.from_server_params(server_params, "translate")
+
+    # Create an agent that can use the translation tool
+    model_client = OpenAIChatCompletionClient(model="gpt-4")
+    agent = AssistantAgent(
+        name="translator",
+        model_client=model_client,
+        tools=[adapter],
+        system_message="You are a helpful translation assistant.",
+    )
+
+    # Let the agent translate some text
+    await Console(
+        agent.run_stream(task="Translate 'Hello, how are you?' to Spanish", cancellation_token=CancellationToken())
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/autogen/agentchat/autogen_mcp_2/autogen_mcp_2.py
+++ b/examples/autogen/agentchat/autogen_mcp_2/autogen_mcp_2.py
@@ -1,0 +1,31 @@
+import asyncio
+from pathlib import Path
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.tools.mcp import StdioServerParams, mcp_server_tools
+from autogen_agentchat.agents import AssistantAgent
+from autogen_core import CancellationToken
+
+
+async def main() -> None:
+    # Setup server params for local filesystem access
+    desktop = str(Path.home() / "Desktop")
+    server_params = StdioServerParams(
+        command="npx.cmd", args=["-y", "@modelcontextprotocol/server-filesystem", desktop]
+    )
+
+    # Get all available tools from the server
+    tools = await mcp_server_tools(server_params)
+
+    # Create an agent that can use all the tools
+    agent = AssistantAgent(
+        name="file_manager",
+        model_client=OpenAIChatCompletionClient(model="gpt-4"),
+        tools=tools,  # type: ignore
+    )
+
+    # The agent can now use any of the filesystem tools
+    await agent.run(task="Create a file called test.txt with some content", cancellation_token=CancellationToken())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Enables MCP Server detection for Autogen AgenChat workflows.
Analyzer searches for usage patterns shown in [Autogen docs](https://microsoft.github.io/autogen/stable//reference/python/autogen_ext.tools.mcp.html#autogen_ext.tools.mcp.mcp_server_tools).

Two main usage patterns covered:
1. Invididual adapters for each tool
```
server_params = <some_params_object>(...)
adapter = await <some_adapter>.from_server_params(server_params, "some_mcp_tool")
agent = <some_agent>(..., tools=[tool1, tool2, adapter])
```

2. List of adapters from server params
```
server_params = <some_params_object>(...)
mcp_tools = await mcp_server_tools(server_params)
agent = <some_agent>(..., tools=mcp_tools)
```

Potential TODOs/improvements for the future:
- detect tool concatenation with `+`, handle all cases of operands (list literal vs variable assigned somewhere before in code)
